### PR TITLE
ci: add Codecov Test Analytics via cargo-nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+# JUnit output for Codecov Test Analytics (used by the `ci` profile in CI).
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,6 +58,12 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --profile ci
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/nextest/ci/junit.xml
 
   coverage:
     name: Coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,8 +64,6 @@ jobs:
         with:
           report_type: test_results
           files: target/nextest/ci/junit.xml
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   coverage:
     name: Coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: cargo test
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --profile ci
 
   coverage:
     name: Coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,10 +60,12 @@ jobs:
       - run: cargo nextest run --profile ci
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           files: target/nextest/ci/junit.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   coverage:
     name: Coverage


### PR DESCRIPTION
Generate JUnit XML with cargo-nextest and upload it to Codecov Test Analytics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to use `nextest` for improved test execution and reporting.
  * Integrated Codecov Test Analytics for better test visibility and tracking in continuous integration.
  * Configured JUnit test result output for CI workflows to enable detailed test analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->