### PR TITLE
feat(parser): align parsing with observed SDK contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@
 
 Reverse-engineered tooling and SDK for converting Samsung Notes (`.sdocx`) files.
 
+## Parser accuracy
+
+`sdocx` is a reverse-engineered parser, not a drop-in implementation of
+Samsung's S Pen SDK. Archive structure, format versions, page ordering, and
+supported packed stroke channels follow observed SDK contracts. Higher-level
+page objects, rich text, templates, and media associations are currently
+best-effort.
+
+A successful parse may omit unsupported objects or properties; it does not
+guarantee a lossless decode. Preserve original documents and validate output
+against Samsung Notes when fidelity matters. Protected documents must be
+unlocked or exported before parsing.
+
 ## Installation
 
 ### CLI

--- a/crates/sdocx-cli/src/main.rs
+++ b/crates/sdocx-cli/src/main.rs
@@ -356,7 +356,9 @@ fn render_stroke(svg: &mut String, stroke: &Stroke, default_ink: &str) {
     if has_pressure {
         for j in 1..stroke.points.len() {
             let p_idx = (j - 1).min(stroke.pressures.len() - 1);
-            let pressure = stroke.pressures[p_idx].max(0.05);
+            // Preserve raw SDK pressure values in the model, but keep malformed or
+            // unsupported records from producing unbounded SVG stroke widths.
+            let pressure = stroke.pressures[p_idx].clamp(0.05, 1.0);
             let sw = base_width * (0.3 + 0.7 * pressure);
 
             let p1 = &stroke.points[j - 1];
@@ -497,8 +499,8 @@ mod tests {
                 points: vec![Point { x: 1.0, y: 1.0 }, Point { x: 9.0, y: 9.0 }],
                 pressures: Vec::new(),
                 timestamps: Vec::new(),
-                tilt_x: Vec::new(),
-                tilt_y: Vec::new(),
+                tilts: Vec::new(),
+                orientations: Vec::new(),
                 color: None,
                 pen_width: 2.0,
             }],
@@ -524,6 +526,17 @@ mod tests {
             "dark-mode default ink"
         );
         assert!(!svg.contains(r##"stroke="#1a1a1a""##));
+    }
+
+    #[test]
+    fn clamps_pressure_when_rendering_strokes() {
+        let mut page = page_with_uncolored_stroke();
+        page.strokes[0].pressures = vec![f64::MAX, f64::MAX];
+
+        let svg = render_page_svg(&page, None, &[], false);
+
+        assert!(svg.contains(r#"stroke-width="0.80""#));
+        assert!(!svg.contains("inf"));
     }
 
     #[test]

--- a/crates/sdocx-cli/src/main.rs
+++ b/crates/sdocx-cli/src/main.rs
@@ -174,6 +174,7 @@ fn render_element(
             .unwrap();
         }
         PageElement::TextBox(text_box) => render_text_box(svg, text_box, page),
+        _ => {}
     }
 }
 
@@ -438,6 +439,7 @@ fn format_template(template: PageTemplate) -> String {
         PageTemplateSource::CustomPdf { page_index } => {
             format!("custom PDF page {}", page_index + 1)
         }
+        _ => format!("template {}", template.id),
     }
 }
 

--- a/crates/sdocx/src/container.rs
+++ b/crates/sdocx/src/container.rs
@@ -1,68 +1,75 @@
-use std::io::{Read, Seek};
+use std::collections::{HashMap, VecDeque};
+use std::io::{Read, Seek, SeekFrom};
 
 use crate::error::{Error, Result};
 use crate::page::parse_page;
 use crate::types::{
-    BoundingBox, Color, Document, DocumentMetadata, MediaAsset, Page, RichTextBox, RichTextRun,
+    BoundingBox, Color, Document, DocumentMetadata, FormatVersion, MediaAsset, Page, RichTextBox,
+    RichTextRun,
 };
+use crate::{ParseLimits, ParseOptions};
+
+const PROTECTED_DOCUMENT_MARKER: &[u8] = b"Document for S-Pen SDK";
 
 /// Parse a `.sdocx` ZIP archive from a reader.
-pub fn parse_from_reader<R: Read + Seek>(reader: R) -> Result<Document> {
+pub fn parse_from_reader<R: Read + Seek>(
+    mut reader: R,
+    options: &ParseOptions,
+) -> Result<Document> {
+    if is_protected_document(&mut reader)? {
+        return Err(Error::ProtectedDocument);
+    }
+    reader.seek(SeekFrom::Start(0))?;
     let mut archive = zip::ZipArchive::new(reader)?;
+    validate_archive(&mut archive, &options.limits)?;
 
     let mut metadata = DocumentMetadata::default();
 
     // Parse end_tag.bin (optional — graceful degradation)
-    if let Ok(mut entry) = archive.by_name("end_tag.bin") {
-        let mut buf = Vec::new();
-        entry.read_to_end(&mut buf)?;
+    if let Some(buf) = read_optional_entry(&mut archive, "end_tag.bin", &options.limits)? {
         parse_end_tag(&buf, &mut metadata);
     }
 
     let mut note_text = None;
 
     // Parse note.note (optional)
-    if let Ok(mut entry) = archive.by_name("note.note") {
-        let mut buf = Vec::new();
-        entry.read_to_end(&mut buf)?;
+    if let Some(buf) = read_optional_entry(&mut archive, "note.note", &options.limits)? {
         parse_note_note(&buf, &mut metadata);
         note_text = parse_note_text(&buf);
     }
 
     // Parse pageIdInfo.dat (optional)
-    if let Ok(mut entry) = archive.by_name("pageIdInfo.dat") {
-        let mut buf = Vec::new();
-        entry.read_to_end(&mut buf)?;
-        parse_page_id_info(&buf, &mut metadata);
+    if let Some(buf) = read_optional_entry(&mut archive, "pageIdInfo.dat", &options.limits)? {
+        parse_page_id_info(&buf, &mut metadata, &options.limits)?;
     }
 
     // Find and parse all .page files
-    let page_names: Vec<String> = (0..archive.len())
-        .filter_map(|i| {
-            let entry = archive.by_index(i).ok()?;
+    let mut page_names = Vec::new();
+    for index in 0..archive.len() {
+        let name = {
+            let entry = archive.by_index(index)?;
             let name = entry.name().to_string();
-            if name.ends_with(".page") {
-                Some(name)
-            } else {
-                None
-            }
-        })
-        .collect();
+            name.ends_with(".page").then_some(name)
+        };
+        if let Some(name) = name {
+            page_names.push(name);
+        }
+    }
 
     if page_names.is_empty() {
         return Err(Error::Format("no .page files found in archive".into()));
     }
+    check_limit("page count", options.limits.max_pages, page_names.len())?;
 
-    metadata.media_assets = parse_media_assets(&mut archive)?;
+    metadata.media_assets = parse_media_assets(&mut archive, &options.limits)?;
 
     let mut pages: Vec<Page> = Vec::with_capacity(page_names.len());
     for name in &page_names {
-        let mut entry = archive.by_name(name)?;
-        let mut buf = Vec::with_capacity(entry.size() as usize);
-        entry.read_to_end(&mut buf)?;
-        let page = parse_page(&buf)?;
+        let buf = read_required_entry(&mut archive, name, &options.limits)?;
+        let page = parse_page(&buf, &options.limits)?;
         pages.push(page);
     }
+    pages = order_pages(pages, &metadata.page_ids);
 
     if let (Some(page), Some(text)) = (pages.first_mut(), note_text.clone()) {
         page.elements.push(crate::types::PageElement::TextBox(text));
@@ -72,8 +79,157 @@ pub fn parse_from_reader<R: Read + Seek>(reader: R) -> Result<Document> {
     Ok(Document { pages, metadata })
 }
 
+fn validate_archive<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    limits: &ParseLimits,
+) -> Result<()> {
+    check_limit(
+        "archive entry count",
+        limits.max_archive_entries,
+        archive.len(),
+    )?;
+
+    let mut total_size = 0_u64;
+    for index in 0..archive.len() {
+        let entry = archive.by_index(index)?;
+        check_u64_limit("archive entry size", limits.max_entry_size, entry.size())?;
+        total_size = total_size
+            .checked_add(entry.size())
+            .ok_or(Error::LimitExceeded {
+                resource: "total uncompressed size",
+                limit: limits.max_total_uncompressed_size,
+                actual: u64::MAX,
+            })?;
+        check_u64_limit(
+            "total uncompressed size",
+            limits.max_total_uncompressed_size,
+            total_size,
+        )?;
+    }
+    Ok(())
+}
+
+fn read_optional_entry<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    name: &str,
+    limits: &ParseLimits,
+) -> Result<Option<Vec<u8>>> {
+    match archive.by_name(name) {
+        Ok(entry) => read_zip_entry(entry, limits).map(Some),
+        Err(zip::result::ZipError::FileNotFound) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn read_required_entry<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    name: &str,
+    limits: &ParseLimits,
+) -> Result<Vec<u8>> {
+    let entry = archive.by_name(name)?;
+    read_zip_entry(entry, limits)
+}
+
+fn read_zip_entry<R: Read>(
+    entry: zip::read::ZipFile<'_, R>,
+    limits: &ParseLimits,
+) -> Result<Vec<u8>> {
+    check_u64_limit("archive entry size", limits.max_entry_size, entry.size())?;
+    let mut data = Vec::new();
+    entry
+        .take(limits.max_entry_size.saturating_add(1))
+        .read_to_end(&mut data)?;
+    check_u64_limit(
+        "archive entry size",
+        limits.max_entry_size,
+        u64::try_from(data.len()).unwrap_or(u64::MAX),
+    )?;
+    Ok(data)
+}
+
+fn is_protected_document<R: Read + Seek>(reader: &mut R) -> std::io::Result<bool> {
+    let len = reader.seek(SeekFrom::End(0))?;
+    reader.seek(SeekFrom::Start(0))?;
+
+    let mut magic = [0_u8; 4];
+    let magic_len = reader.read(&mut magic)?;
+    if magic_len >= 2 && &magic[..2] == b"PK" {
+        reader.seek(SeekFrom::Start(0))?;
+        return Ok(false);
+    }
+
+    let tail_len = len.min(4096);
+    reader.seek(SeekFrom::Start(len.saturating_sub(tail_len)))?;
+    let mut tail = Vec::new();
+    reader.take(tail_len).read_to_end(&mut tail)?;
+    reader.seek(SeekFrom::Start(0))?;
+
+    Ok(tail
+        .windows(PROTECTED_DOCUMENT_MARKER.len())
+        .any(|window| window == PROTECTED_DOCUMENT_MARKER))
+}
+
+fn check_limit(resource: &'static str, limit: usize, actual: usize) -> Result<()> {
+    check_u64_limit(
+        resource,
+        u64::try_from(limit).unwrap_or(u64::MAX),
+        u64::try_from(actual).unwrap_or(u64::MAX),
+    )
+}
+
+fn check_u64_limit(resource: &'static str, limit: u64, actual: u64) -> Result<()> {
+    if actual > limit {
+        Err(Error::LimitExceeded {
+            resource,
+            limit,
+            actual,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn order_pages(pages: Vec<Page>, page_ids: &[String]) -> Vec<Page> {
+    let mut indexes_by_id: HashMap<String, VecDeque<usize>> = HashMap::new();
+    for (index, page) in pages.iter().enumerate() {
+        indexes_by_id
+            .entry(page.uuid.clone())
+            .or_default()
+            .push_back(index);
+    }
+
+    let mut selected = vec![false; pages.len()];
+    let mut ordered_indexes = Vec::with_capacity(pages.len());
+    for page_id in page_ids {
+        if let Some(index) = indexes_by_id.get_mut(page_id).and_then(VecDeque::pop_front) {
+            selected[index] = true;
+            ordered_indexes.push(index);
+        }
+    }
+    ordered_indexes.extend(
+        selected
+            .iter()
+            .enumerate()
+            .filter_map(|(index, selected)| (!selected).then_some(index)),
+    );
+
+    let mut pages: Vec<Option<Page>> = pages.into_iter().map(Some).collect();
+    ordered_indexes
+        .into_iter()
+        .filter_map(|index| pages[index].take())
+        .collect()
+}
+
 /// Extract timestamps from `end_tag.bin`.
 fn parse_end_tag(data: &[u8], metadata: &mut DocumentMetadata) {
+    if let Some(version) = data
+        .get(0x02..0x04)
+        .and_then(|bytes| bytes.try_into().ok())
+        .map(u16::from_le_bytes)
+        .filter(|version| *version != 0)
+    {
+        metadata.format_version = Some(FormatVersion(version));
+    }
     if data.len() < 0x58 {
         return;
     }
@@ -85,6 +241,14 @@ fn parse_end_tag(data: &[u8], metadata: &mut DocumentMetadata) {
 
 /// Extract background color and page dimensions from `note.note`.
 fn parse_note_note(data: &[u8], metadata: &mut DocumentMetadata) {
+    if metadata.format_version.is_none() {
+        metadata.format_version = data
+            .get(0x0E..0x10)
+            .and_then(|bytes| bytes.try_into().ok())
+            .map(u16::from_le_bytes)
+            .filter(|version| *version != 0)
+            .map(FormatVersion);
+    }
     if data.len() >= 0x08 {
         let flags = u32::from_le_bytes(data[0x04..0x08].try_into().unwrap());
         metadata.dark_mode_compatibility = Some(flags & 0x0800 != 0);
@@ -118,10 +282,14 @@ fn parse_note_note(data: &[u8], metadata: &mut DocumentMetadata) {
     }
 }
 
-fn parse_media_assets<R: Read + Seek>(archive: &mut zip::ZipArchive<R>) -> Result<Vec<MediaAsset>> {
-    let mut names: Vec<String> = (0..archive.len())
-        .filter_map(|i| {
-            let entry = archive.by_index(i).ok()?;
+fn parse_media_assets<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    limits: &ParseLimits,
+) -> Result<Vec<MediaAsset>> {
+    let mut names = Vec::new();
+    for index in 0..archive.len() {
+        let name = {
+            let entry = archive.by_index(index)?;
             let name = entry.name().to_string();
             let lower = name.to_ascii_lowercase();
             if name.starts_with("media/")
@@ -134,8 +302,11 @@ fn parse_media_assets<R: Read + Seek>(archive: &mut zip::ZipArchive<R>) -> Resul
             } else {
                 None
             }
-        })
-        .collect();
+        };
+        if let Some(name) = name {
+            names.push(name);
+        }
+    }
     names.sort_by_key(|name| {
         name.rsplit('/')
             .next()
@@ -146,9 +317,7 @@ fn parse_media_assets<R: Read + Seek>(archive: &mut zip::ZipArchive<R>) -> Resul
 
     let mut assets = Vec::with_capacity(names.len());
     for name in names {
-        let mut entry = archive.by_name(&name)?;
-        let mut data = Vec::with_capacity(entry.size() as usize);
-        entry.read_to_end(&mut data)?;
+        let data = read_required_entry(archive, &name, limits)?;
         let lower = name.to_ascii_lowercase();
         let mime_type = if lower.ends_with(".png") {
             "image/png"
@@ -300,36 +469,69 @@ fn collect_style_runs(
 }
 
 /// Extract page UUIDs from `pageIdInfo.dat`.
-fn parse_page_id_info(data: &[u8], metadata: &mut DocumentMetadata) {
-    if data.len() < 0x24 {
-        return;
+fn parse_page_id_info(
+    data: &[u8],
+    metadata: &mut DocumentMetadata,
+    limits: &ParseLimits,
+) -> Result<()> {
+    if data.len() < 0x22 {
+        return Ok(());
     }
     let count = u16::from_le_bytes(data[0x20..0x22].try_into().unwrap()) as usize;
-    let mut offset = 0x22;
+    check_limit("page count", limits.max_pages, count)?;
+    let mut offset: usize = 0x22;
 
     for _ in 0..count {
-        if offset + 2 > data.len() {
+        let Some(length_end) = offset.checked_add(2) else {
             break;
-        }
-        let char_len = u16::from_le_bytes(data[offset..offset + 2].try_into().unwrap()) as usize;
-        offset += 2;
-        if offset + char_len * 2 > data.len() {
+        };
+        let Some(length_bytes) = data.get(offset..length_end) else {
             break;
-        }
-        let uuid: String = data[offset..offset + char_len * 2]
-            .chunks_exact(2)
+        };
+        let char_len = u16::from_le_bytes(length_bytes.try_into().unwrap()) as usize;
+        offset = length_end;
+        let Some(byte_len) = char_len.checked_mul(2) else {
+            break;
+        };
+        let Some(uuid_end) = offset.checked_add(byte_len) else {
+            break;
+        };
+        let Some(uuid_bytes) = data.get(offset..uuid_end) else {
+            break;
+        };
+        let uuid: String = uuid_bytes
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| u16::from_le_bytes([c[0], c[1]]))
             .map(|c| char::from_u32(c as u32).unwrap_or('\u{FFFD}'))
             .collect();
         metadata.page_ids.push(uuid);
-        offset += char_len * 2;
+        offset = uuid_end;
     }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::parse_note_note;
-    use crate::types::DocumentMetadata;
+    use std::io::Cursor;
+
+    use super::{order_pages, parse_end_tag, parse_from_reader, parse_note_note};
+    use crate::types::{BoundingBox, DocumentMetadata, FormatVersion, Page};
+    use crate::{Error, ParseOptions};
+
+    fn page(uuid: &str) -> Page {
+        Page {
+            uuid: uuid.to_string(),
+            width: 1,
+            height: 1,
+            content_bbox: BoundingBox::default(),
+            background_color: None,
+            template: None,
+            strokes: Vec::new(),
+            elements: Vec::new(),
+        }
+    }
 
     #[test]
     fn parses_dark_mode_compatibility_flag() {
@@ -345,5 +547,43 @@ mod tests {
         parse_note_note(&data, &mut metadata);
 
         assert_eq!(metadata.dark_mode_compatibility, Some(false));
+    }
+
+    #[test]
+    fn parses_format_version_with_note_fallback() {
+        let mut metadata = DocumentMetadata::default();
+        let mut note = vec![0; 0x10];
+        note[0x0E..0x10].copy_from_slice(&4000_u16.to_le_bytes());
+        parse_note_note(&note, &mut metadata);
+        assert_eq!(metadata.format_version, Some(FormatVersion(4000)));
+
+        let mut end_tag = vec![0; 4];
+        end_tag[0x02..0x04].copy_from_slice(&5500_u16.to_le_bytes());
+        parse_end_tag(&end_tag, &mut metadata);
+        assert_eq!(metadata.format_version, Some(FormatVersion::CURRENT));
+    }
+
+    #[test]
+    fn orders_pages_by_page_id_info_then_preserves_unlisted_order() {
+        let pages = vec![page("second"), page("unlisted"), page("first")];
+        let ids = vec!["first".to_string(), "second".to_string()];
+
+        let ordered = order_pages(pages, &ids);
+
+        assert_eq!(
+            ordered
+                .iter()
+                .map(|page| page.uuid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "second", "unlisted"]
+        );
+    }
+
+    #[test]
+    fn reports_protected_document_marker() {
+        let bytes = b"encrypted payload Document for S-Pen SDK";
+        let error = parse_from_reader(Cursor::new(bytes), &ParseOptions::default()).unwrap_err();
+
+        assert!(matches!(error, Error::ProtectedDocument));
     }
 }

--- a/crates/sdocx/src/container.rs
+++ b/crates/sdocx/src/container.rs
@@ -307,13 +307,7 @@ fn parse_media_assets<R: Read + Seek>(
             names.push(name);
         }
     }
-    names.sort_by_key(|name| {
-        name.rsplit('/')
-            .next()
-            .and_then(|file| file.split('@').next())
-            .and_then(|prefix| prefix.parse::<usize>().ok())
-            .unwrap_or(usize::MAX)
-    });
+    names.sort_by_key(|name| media_archive_id(name).map(u64::from).unwrap_or(u64::MAX));
 
     let mut assets = Vec::with_capacity(names.len());
     for name in names {
@@ -327,12 +321,17 @@ fn parse_media_assets<R: Read + Seek>(
             "image/jpeg"
         };
         assets.push(MediaAsset {
+            archive_id: media_archive_id(&name),
             name,
             mime_type: mime_type.to_string(),
             data,
         });
     }
     Ok(assets)
+}
+
+fn media_archive_id(name: &str) -> Option<u32> {
+    name.rsplit('/').next()?.split('@').next()?.parse().ok()
 }
 
 fn parse_note_text(data: &[u8]) -> Option<RichTextBox> {

--- a/crates/sdocx/src/decode.rs
+++ b/crates/sdocx/src/decode.rs
@@ -77,12 +77,14 @@ pub struct TrailingData {
 ///
 /// Pressure, timestamp, tilt, and orientation each store their first value in
 /// full (four bytes), followed by `n_points - 1` two-byte deltas. Tilt and
-/// orientation are optional as a pair. The returned vectors therefore line up
-/// one-for-one with `Stroke::points`.
+/// orientation are optional as a pair and are decoded only when the containing
+/// stroke property flags explicitly declare them. The returned vectors
+/// therefore line up one-for-one with `Stroke::points`.
 pub fn decode_trailing(
     data_blob: &[u8],
     n_coord_bytes: usize,
     n_points: usize,
+    has_stylus_channels: bool,
 ) -> Option<TrailingData> {
     if n_points == 0 {
         return None;
@@ -94,7 +96,7 @@ pub fn decode_trailing(
     let pressures = decode_float_channel(data_blob, &mut cursor, delta_count)?;
     let timestamps = decode_timestamp_channel(data_blob, &mut cursor, delta_count)?;
 
-    let (tilts, orientations) = if has_plausible_stylus_channels(data_blob, cursor, delta_count) {
+    let (tilts, orientations) = if has_stylus_channels {
         let tilts = decode_float_channel(data_blob, &mut cursor, delta_count)?;
         let orientations = decode_float_channel(data_blob, &mut cursor, delta_count)?;
         (tilts, orientations)
@@ -155,39 +157,6 @@ fn decode_timestamp_channel(
         values.push(value);
     }
     Some(values)
-}
-
-fn has_plausible_stylus_channels(data: &[u8], cursor: usize, delta_count: usize) -> bool {
-    let channel_len = match delta_count
-        .checked_mul(2)
-        .and_then(|len| len.checked_add(4))
-    {
-        Some(len) => len,
-        None => return false,
-    };
-    let end = match channel_len
-        .checked_mul(2)
-        .and_then(|len| cursor.checked_add(len))
-    {
-        Some(end) if end <= data.len() => end,
-        _ => return false,
-    };
-
-    // A stroke's flexible style data follows the point channels. Requiring the
-    // two decoded channels to stay in the SDK's angular range avoids treating a
-    // long style block on non-stylus input as tilt/orientation samples.
-    let mut probe = cursor;
-    let Some(tilts) = decode_float_channel(data, &mut probe, delta_count) else {
-        return false;
-    };
-    let Some(orientations) = decode_float_channel(data, &mut probe, delta_count) else {
-        return false;
-    };
-    probe == end
-        && tilts
-            .iter()
-            .chain(&orientations)
-            .all(|value| value.is_finite() && value.abs() <= std::f64::consts::TAU + f64::EPSILON)
 }
 
 fn read_f32(data: &[u8], offset: usize) -> Option<f32> {
@@ -360,7 +329,7 @@ mod tests {
         blob.extend_from_slice(&5_u16.to_le_bytes());
         blob.extend_from_slice(&7_u16.to_le_bytes());
 
-        let result = decode_trailing(&blob, n_coord_bytes, n_points).unwrap();
+        let result = decode_trailing(&blob, n_coord_bytes, n_points, false).unwrap();
         assert_eq!(result.pressures.len(), 3);
         assert_eq!(result.pressures, vec![0.25, 0.375, 0.3125]);
         assert_eq!(result.timestamps, vec![1000, 1005, 1012]);
@@ -382,7 +351,7 @@ mod tests {
         blob.extend_from_slice(&(-1.0_f32).to_le_bytes());
         blob.extend_from_slice(&0x8200_u16.to_le_bytes()); // -0.125
 
-        let result = decode_trailing(&blob, n_coord_bytes, n_points).unwrap();
+        let result = decode_trailing(&blob, n_coord_bytes, n_points, true).unwrap();
         assert_eq!(result.tilts, vec![0.25, 0.5]);
         assert_eq!(result.orientations, vec![-1.0, -1.125]);
     }

--- a/crates/sdocx/src/decode.rs
+++ b/crates/sdocx/src/decode.rs
@@ -1,5 +1,5 @@
-const DELTA_SCALE: f64 = 1.0 / 32.0;
-const MAX_PRESSURE: f64 = 1400.0;
+const POINT_DELTA_SCALE: f64 = 1.0 / 32.0;
+const FLOAT_DELTA_SCALE: f64 = 1.0 / 4096.0;
 /// Color marker: leading byte is a format version (0x02 on older Samsung Notes,
 /// 0x03 on v4.4.x+) followed by this fixed 5-byte tail.
 const COLOR_MARKER_TAIL: &[u8] = &[0x00, 0x01, 0x00, 0x00, 0x00];
@@ -7,24 +7,34 @@ const COLOR_MARKER_LEN: usize = COLOR_MARKER_TAIL.len() + 1;
 
 use crate::types::{Color, Point};
 
-/// Decode sign-magnitude byte pairs: (magnitude, sign_flag).
-/// `0x00` = positive, `0x80` = negative.
-pub fn decode_sign_mag(data: &[u8], offset: usize, count: usize) -> Vec<i64> {
-    let mut vals = Vec::with_capacity(count);
-    for i in 0..count {
-        let pos = offset + i * 2;
-        if pos + 1 >= data.len() {
-            break;
-        }
-        let mag = data[pos] as i64;
-        let sign = data[pos + 1];
-        vals.push(if sign == 0x00 { mag } else { -mag });
+/// Decode Samsung's signed-magnitude Q10.5 point delta.
+///
+/// Bit 15 is the sign and bits 0..=14 hold the magnitude. This matches the
+/// `ObjectStrokeBinaryHandler::sm_RestoreStroke` implementation in Samsung's
+/// S Pen SDK. Treating the high byte as a sign flag loses seven magnitude bits.
+fn decode_point_delta(raw: u16) -> f64 {
+    let magnitude = f64::from(raw & 0x7fff) * POINT_DELTA_SCALE;
+    if raw & 0x8000 == 0 {
+        magnitude
+    } else {
+        -magnitude
     }
-    vals
 }
 
-/// Decode delta-encoded coordinates. Each quartet is `[dx_mag, dx_flag, dy_mag, dy_flag]`;
-/// bit 7 of each flag is the sign, lower bits are ignored (they carry metadata on v4.4.x+).
+/// Decode Samsung's signed-magnitude Q3.12 floating-point delta.
+///
+/// This representation is used by pressure, tilt, and orientation channels.
+fn decode_float_delta(raw: u16) -> f64 {
+    let magnitude = f64::from(raw & 0x7fff) * FLOAT_DELTA_SCALE;
+    if raw & 0x8000 == 0 {
+        magnitude
+    } else {
+        -magnitude
+    }
+}
+
+/// Decode delta-encoded coordinates. Each quartet contains little-endian Q10.5
+/// signed-magnitude words for `dx` and `dy`.
 ///
 /// Reads exactly `n_deltas` quartets, producing `n_deltas + 1` points (including the start).
 /// Stops early if `data` runs out. Returns `(points, n_coord_bytes)`.
@@ -37,25 +47,12 @@ pub fn decode_coordinates(
     let mut x = start_x;
     let mut y = start_y;
     let mut points = vec![Point { x, y }];
-    let limit = n_deltas * 4;
+    let limit = n_deltas.saturating_mul(4);
     let mut i = 0;
 
     while i + 3 < data.len() && i < limit {
-        let dx_mag = data[i];
-        let dx_flag = data[i + 1];
-        let dy_mag = data[i + 2];
-        let dy_flag = data[i + 3];
-
-        let dx = if dx_flag & 0x80 == 0 {
-            dx_mag as f64
-        } else {
-            -(dx_mag as f64)
-        } * DELTA_SCALE;
-        let dy = if dy_flag & 0x80 == 0 {
-            dy_mag as f64
-        } else {
-            -(dy_mag as f64)
-        } * DELTA_SCALE;
+        let dx = decode_point_delta(u16::from_le_bytes([data[i], data[i + 1]]));
+        let dy = decode_point_delta(u16::from_le_bytes([data[i + 2], data[i + 3]]));
 
         x += dx;
         y += dy;
@@ -70,55 +67,137 @@ pub fn decode_coordinates(
 pub struct TrailingData {
     pub pressures: Vec<f64>,
     pub timestamps: Vec<i64>,
-    pub tilt_x: Vec<i64>,
-    pub tilt_y: Vec<i64>,
+    pub tilts: Vec<f64>,
+    pub orientations: Vec<f64>,
     pub color: Option<Color>,
     pub pen_width: f32,
 }
 
-/// Decode all trailing data: per-point channels (pressure, timestamp, tilt_x, tilt_y)
-/// and per-stroke color + pen width.
-pub fn decode_trailing(data_blob: &[u8], n_coord_bytes: usize, n_points: usize) -> TrailingData {
-    let trail_start = n_coord_bytes + 4; // 4-byte gap after coordinates
-
-    // Decode 4 per-point channels
-    let mut channels: [Vec<i64>; 4] = Default::default();
-    for (ch_idx, channel) in channels.iter_mut().enumerate() {
-        let ch_offset = trail_start + ch_idx * n_points * 2;
-        if ch_offset + n_points * 2 > data_blob.len() {
-            continue;
-        }
-        let deltas = decode_sign_mag(data_blob, ch_offset, n_points);
-        let mut cumsum: i64 = 0;
-        let mut values = Vec::with_capacity(deltas.len());
-        for d in deltas {
-            cumsum += d;
-            values.push(cumsum);
-        }
-        *channel = values;
+/// Decode the compressed per-point channels following the coordinate deltas.
+///
+/// Pressure, timestamp, tilt, and orientation each store their first value in
+/// full (four bytes), followed by `n_points - 1` two-byte deltas. Tilt and
+/// orientation are optional as a pair. The returned vectors therefore line up
+/// one-for-one with `Stroke::points`.
+pub fn decode_trailing(
+    data_blob: &[u8],
+    n_coord_bytes: usize,
+    n_points: usize,
+) -> Option<TrailingData> {
+    if n_points == 0 {
+        return None;
     }
 
-    // Normalize pressure to 0.0..1.0
-    let pressures: Vec<f64> = channels[0]
-        .iter()
-        .map(|&v| (v as f64 / MAX_PRESSURE).clamp(0.0, 1.0))
-        .collect();
+    let delta_count = n_points - 1;
+    let mut cursor = n_coord_bytes;
 
-    let timestamps = std::mem::take(&mut channels[1]);
-    let tilt_x = std::mem::take(&mut channels[2]);
-    let tilt_y = std::mem::take(&mut channels[3]);
+    let pressures = decode_float_channel(data_blob, &mut cursor, delta_count)?;
+    let timestamps = decode_timestamp_channel(data_blob, &mut cursor, delta_count)?;
+
+    let (tilts, orientations) = if has_plausible_stylus_channels(data_blob, cursor, delta_count) {
+        let tilts = decode_float_channel(data_blob, &mut cursor, delta_count)?;
+        let orientations = decode_float_channel(data_blob, &mut cursor, delta_count)?;
+        (tilts, orientations)
+    } else {
+        (Vec::new(), Vec::new())
+    };
 
     // Extract color and pen width from the color marker
     let (color, pen_width) = extract_color_and_width(data_blob);
 
-    TrailingData {
+    Some(TrailingData {
         pressures,
         timestamps,
-        tilt_x,
-        tilt_y,
+        tilts,
+        orientations,
         color,
         pen_width,
+    })
+}
+
+fn decode_float_channel(data: &[u8], cursor: &mut usize, delta_count: usize) -> Option<Vec<f64>> {
+    let first = read_f32(data, *cursor)? as f64;
+    *cursor = cursor.checked_add(4)?;
+
+    let byte_len = delta_count.checked_mul(2)?;
+    let end = cursor.checked_add(byte_len)?;
+    let deltas = data.get(*cursor..end)?;
+    *cursor = end;
+
+    let mut value = first;
+    let mut values = Vec::with_capacity(delta_count + 1);
+    values.push(value);
+    for raw in deltas.as_chunks::<2>().0 {
+        value += decode_float_delta(u16::from_le_bytes([raw[0], raw[1]]));
+        values.push(value);
     }
+    Some(values)
+}
+
+fn decode_timestamp_channel(
+    data: &[u8],
+    cursor: &mut usize,
+    delta_count: usize,
+) -> Option<Vec<i64>> {
+    let mut value = i64::from(read_i32(data, *cursor)?);
+    *cursor = cursor.checked_add(4)?;
+
+    let byte_len = delta_count.checked_mul(2)?;
+    let end = cursor.checked_add(byte_len)?;
+    let deltas = data.get(*cursor..end)?;
+    *cursor = end;
+
+    let mut values = Vec::with_capacity(delta_count + 1);
+    values.push(value);
+    for raw in deltas.as_chunks::<2>().0 {
+        // The native reader zero-extends the stored 16-bit timestamp delta.
+        value += i64::from(u16::from_le_bytes([raw[0], raw[1]]));
+        values.push(value);
+    }
+    Some(values)
+}
+
+fn has_plausible_stylus_channels(data: &[u8], cursor: usize, delta_count: usize) -> bool {
+    let channel_len = match delta_count
+        .checked_mul(2)
+        .and_then(|len| len.checked_add(4))
+    {
+        Some(len) => len,
+        None => return false,
+    };
+    let end = match channel_len
+        .checked_mul(2)
+        .and_then(|len| cursor.checked_add(len))
+    {
+        Some(end) if end <= data.len() => end,
+        _ => return false,
+    };
+
+    // A stroke's flexible style data follows the point channels. Requiring the
+    // two decoded channels to stay in the SDK's angular range avoids treating a
+    // long style block on non-stylus input as tilt/orientation samples.
+    let mut probe = cursor;
+    let Some(tilts) = decode_float_channel(data, &mut probe, delta_count) else {
+        return false;
+    };
+    let Some(orientations) = decode_float_channel(data, &mut probe, delta_count) else {
+        return false;
+    };
+    probe == end
+        && tilts
+            .iter()
+            .chain(&orientations)
+            .all(|value| value.is_finite() && value.abs() <= std::f64::consts::TAU + f64::EPSILON)
+}
+
+fn read_f32(data: &[u8], offset: usize) -> Option<f32> {
+    let end = offset.checked_add(4)?;
+    Some(f32::from_le_bytes(data.get(offset..end)?.try_into().ok()?))
+}
+
+fn read_i32(data: &[u8], offset: usize) -> Option<i32> {
+    let end = offset.checked_add(4)?;
+    Some(i32::from_le_bytes(data.get(offset..end)?.try_into().ok()?))
 }
 
 fn extract_color_and_width(data_blob: &[u8]) -> (Option<Color>, f32) {
@@ -155,34 +234,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_decode_sign_mag_positive() {
-        let data = [42, 0x00, 10, 0x00];
-        let vals = decode_sign_mag(&data, 0, 2);
-        assert_eq!(vals, vec![42, 10]);
-    }
-
-    #[test]
-    fn test_decode_sign_mag_negative() {
-        let data = [42, 0x80, 10, 0x80];
-        let vals = decode_sign_mag(&data, 0, 2);
-        assert_eq!(vals, vec![-42, -10]);
-    }
-
-    #[test]
-    fn test_decode_sign_mag_mixed() {
-        let data = [5, 0x00, 3, 0x80, 7, 0x00];
-        let vals = decode_sign_mag(&data, 0, 3);
-        assert_eq!(vals, vec![5, -3, 7]);
-    }
-
-    #[test]
-    fn test_decode_sign_mag_with_offset() {
-        let data = [0xFF, 0xFF, 5, 0x00, 3, 0x80];
-        let vals = decode_sign_mag(&data, 2, 2);
-        assert_eq!(vals, vec![5, -3]);
-    }
-
-    #[test]
     fn test_decode_coordinates_simple() {
         // Two deltas: (+32/32, +64/32) then (+0, -32/32)
         let data = [
@@ -213,15 +264,13 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_coordinates_flag_low_bits_ignored() {
-        // v4.4.x flag bytes carry metadata in low bits; only bit 7 is the sign.
-        let data = [
-            32, 0x05, 64, 0x85, // dx=+1.0 (bit7=0), dy=-2.0 (bit7=1); low bits ignored
-        ];
+    fn test_decode_coordinates_preserves_high_magnitude_bits() {
+        // +300.5 = 0x2590 / 32; -2.25 = -(0x0048 / 32).
+        let data = [0x90, 0x25, 0x48, 0x80];
         let (points, n_bytes) = decode_coordinates(&data, 0.0, 0.0, 1);
         assert_eq!(points.len(), 2);
-        assert!((points[1].x - 1.0).abs() < 1e-10);
-        assert!((points[1].y + 2.0).abs() < 1e-10);
+        assert!((points[1].x - 300.5).abs() < 1e-10);
+        assert!((points[1].y + 2.25).abs() < 1e-10);
         assert_eq!(n_bytes, 4);
     }
 
@@ -299,26 +348,42 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_trailing_pressure() {
-        // Build a minimal data blob: 4 bytes of coord data + 4-byte gap + pressure deltas
+    fn test_decode_trailing_channels() {
         let n_coord_bytes = 4;
         let n_points = 3;
 
-        let mut blob = vec![0u8; 100];
-        // Pressure deltas at offset 8 (n_coord_bytes + 4): [100, +], [50, +], [20, -]
-        let trail_start = n_coord_bytes + 4;
-        blob[trail_start] = 100;
-        blob[trail_start + 1] = 0x00; // +100
-        blob[trail_start + 2] = 50;
-        blob[trail_start + 3] = 0x00; // +50
-        blob[trail_start + 4] = 20;
-        blob[trail_start + 5] = 0x80; // -20
+        let mut blob = vec![0u8; n_coord_bytes];
+        blob.extend_from_slice(&0.25_f32.to_le_bytes());
+        blob.extend_from_slice(&0x0200_u16.to_le_bytes()); // +0.125
+        blob.extend_from_slice(&0x8100_u16.to_le_bytes()); // -0.0625
+        blob.extend_from_slice(&1000_i32.to_le_bytes());
+        blob.extend_from_slice(&5_u16.to_le_bytes());
+        blob.extend_from_slice(&7_u16.to_le_bytes());
 
-        let result = decode_trailing(&blob, n_coord_bytes, n_points);
+        let result = decode_trailing(&blob, n_coord_bytes, n_points).unwrap();
         assert_eq!(result.pressures.len(), 3);
-        // cumsum: 100, 150, 130 -> normalized: 100/1400, 150/1400, 130/1400
-        assert!((result.pressures[0] - 100.0 / 1400.0).abs() < 1e-10);
-        assert!((result.pressures[1] - 150.0 / 1400.0).abs() < 1e-10);
-        assert!((result.pressures[2] - 130.0 / 1400.0).abs() < 1e-10);
+        assert_eq!(result.pressures, vec![0.25, 0.375, 0.3125]);
+        assert_eq!(result.timestamps, vec![1000, 1005, 1012]);
+        assert!(result.tilts.is_empty());
+        assert!(result.orientations.is_empty());
+    }
+
+    #[test]
+    fn test_decode_optional_tilt_and_orientation_channels() {
+        let n_coord_bytes = 0;
+        let n_points = 2;
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&0.5_f32.to_le_bytes());
+        blob.extend_from_slice(&0_u16.to_le_bytes());
+        blob.extend_from_slice(&42_i32.to_le_bytes());
+        blob.extend_from_slice(&3_u16.to_le_bytes());
+        blob.extend_from_slice(&0.25_f32.to_le_bytes());
+        blob.extend_from_slice(&0x0400_u16.to_le_bytes()); // +0.25
+        blob.extend_from_slice(&(-1.0_f32).to_le_bytes());
+        blob.extend_from_slice(&0x8200_u16.to_le_bytes()); // -0.125
+
+        let result = decode_trailing(&blob, n_coord_bytes, n_points).unwrap();
+        assert_eq!(result.tilts, vec![0.25, 0.5]);
+        assert_eq!(result.orientations, vec![-1.0, -1.125]);
     }
 }

--- a/crates/sdocx/src/error.rs
+++ b/crates/sdocx/src/error.rs
@@ -2,6 +2,7 @@ use std::io;
 
 /// Errors that can occur when parsing an `.sdocx` file.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// An I/O error occurred while reading the file.
     #[error("I/O error: {0}")]

--- a/crates/sdocx/src/error.rs
+++ b/crates/sdocx/src/error.rs
@@ -14,6 +14,21 @@ pub enum Error {
     /// The file contents do not match the expected `.sdocx` format.
     #[error("format error: {0}")]
     Format(String),
+
+    /// The file uses Samsung Notes document protection and must be unlocked first.
+    #[error("protected Samsung Notes document; unlock or export it before parsing")]
+    ProtectedDocument,
+
+    /// A configurable parser resource limit was exceeded.
+    #[error("{resource} limit exceeded: {actual} > {limit}")]
+    LimitExceeded {
+        /// Resource whose limit was exceeded.
+        resource: &'static str,
+        /// Configured maximum.
+        limit: u64,
+        /// Value found in the input.
+        actual: u64,
+    },
 }
 
 /// A specialized `Result` type for sdocx operations.

--- a/crates/sdocx/src/lib.rs
+++ b/crates/sdocx/src/lib.rs
@@ -1,3 +1,14 @@
+//! Reverse-engineered parser for Samsung Notes `.sdocx` documents.
+//!
+//! # Accuracy and compatibility
+//!
+//! Archive structure, format versions, page ordering, and supported packed
+//! stroke channels are decoded from observed S Pen SDK contracts. Higher-level
+//! page objects, rich text, templates, and media associations remain
+//! best-effort. A successful parse can omit unsupported content and does not
+//! indicate a lossless decode. Preserve the source document when fidelity is
+//! important.
+
 mod container;
 mod decode;
 mod error;

--- a/crates/sdocx/src/lib.rs
+++ b/crates/sdocx/src/lib.rs
@@ -11,14 +11,64 @@ use std::fs::File;
 use std::io::Cursor;
 use std::path::Path;
 
+/// Resource limits applied while parsing untrusted `.sdocx` input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseLimits {
+    /// Maximum number of entries in the ZIP archive.
+    pub max_archive_entries: usize,
+    /// Maximum declared or decoded size of one archive entry.
+    pub max_entry_size: u64,
+    /// Maximum total declared uncompressed size across archive entries.
+    pub max_total_uncompressed_size: u64,
+    /// Maximum number of pages.
+    pub max_pages: usize,
+    /// Maximum number of strokes declared by one page.
+    pub max_strokes_per_page: usize,
+    /// Maximum number of points declared by one stroke.
+    pub max_points_per_stroke: usize,
+    /// Maximum number of non-stroke objects detected on one page.
+    pub max_objects_per_page: usize,
+}
+
+impl Default for ParseLimits {
+    fn default() -> Self {
+        Self {
+            max_archive_entries: 65_536,
+            max_entry_size: 512 * 1024 * 1024,
+            max_total_uncompressed_size: 2 * 1024 * 1024 * 1024,
+            max_pages: 10_000,
+            max_strokes_per_page: 100_000,
+            max_points_per_stroke: u16::MAX as usize,
+            max_objects_per_page: 100_000,
+        }
+    }
+}
+
+/// Options controlling `.sdocx` parsing.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParseOptions {
+    /// Resource limits for untrusted input.
+    pub limits: ParseLimits,
+}
+
 /// Parse a `.sdocx` file from a filesystem path.
 pub fn parse(path: impl AsRef<Path>) -> Result<Document> {
+    parse_with_options(path, &ParseOptions::default())
+}
+
+/// Parse a `.sdocx` file from a filesystem path with explicit options.
+pub fn parse_with_options(path: impl AsRef<Path>, options: &ParseOptions) -> Result<Document> {
     let file = File::open(path)?;
-    container::parse_from_reader(file)
+    container::parse_from_reader(file, options)
 }
 
 /// Parse a `.sdocx` file from in-memory bytes.
 pub fn parse_bytes(bytes: &[u8]) -> Result<Document> {
+    parse_bytes_with_options(bytes, &ParseOptions::default())
+}
+
+/// Parse in-memory `.sdocx` bytes with explicit options.
+pub fn parse_bytes_with_options(bytes: &[u8], options: &ParseOptions) -> Result<Document> {
     let cursor = Cursor::new(bytes);
-    container::parse_from_reader(cursor)
+    container::parse_from_reader(cursor, options)
 }

--- a/crates/sdocx/src/page.rs
+++ b/crates/sdocx/src/page.rs
@@ -12,6 +12,7 @@ const EXTRA_LEN_BIAS: u8 = 0x79; // byte value at record+3 when no extras are pr
 
 struct ParsedStroke {
     stroke: Stroke,
+    declared_point_count: usize,
     next_record_off: usize,
 }
 
@@ -117,7 +118,7 @@ pub fn parse_page(data: &[u8], limits: &ParseLimits) -> Result<Page> {
         check_limit(
             "points per stroke",
             limits.max_points_per_stroke,
-            parsed.stroke.points.len(),
+            parsed.declared_point_count,
         )?;
 
         record_off = parsed.next_record_off;
@@ -192,7 +193,7 @@ fn parse_stroke(
 
     let (points, n_coord_bytes) =
         decode_coordinates(data_blob, start_x, start_y, n_points.saturating_sub(1));
-    if points.is_empty()
+    if points.len() != n_points
         || points
             .iter()
             .any(|point| !point.x.is_finite() || !point.y.is_finite())
@@ -217,6 +218,7 @@ fn parse_stroke(
             color: trailing.color,
             pen_width: trailing.pen_width,
         },
+        declared_point_count: n_points,
         next_record_off,
     })
 }
@@ -698,6 +700,57 @@ mod tests {
             error,
             Error::LimitExceeded {
                 resource: "strokes per page",
+                limit: 1,
+                actual: 2,
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_incomplete_declared_point_data() {
+        let mut data = vec![0; super::STROKE_HEADER_LEN + 4];
+        data[53..57].copy_from_slice(&4_u32.to_le_bytes());
+        data[71..73].copy_from_slice(&3_u16.to_le_bytes());
+
+        let parsed = super::parse_stroke(&data, 0, 0, super::StrokeLayout::Current);
+
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn enforces_declared_point_count_limit() {
+        let mut data = vec![0; 0x140];
+        data[0x66..0x6A].copy_from_slice(&1_u32.to_le_bytes());
+
+        let stroke_off = 0xB5;
+        let meta_off = stroke_off + 32;
+        let start_point_off = stroke_off + 73;
+        let data_off = start_point_off + 16;
+        data[meta_off + 21..meta_off + 25].copy_from_slice(&16_u32.to_le_bytes());
+        data[meta_off + 39..meta_off + 41].copy_from_slice(&2_u16.to_le_bytes());
+
+        let mut cursor = data_off;
+        for bytes in [
+            [32, 0, 32, 0],
+            0.5_f32.to_le_bytes(),
+            [0, 0, 100, 0],
+            [0, 0, 1, 0],
+        ] {
+            data[cursor..cursor + bytes.len()].copy_from_slice(&bytes);
+            cursor += bytes.len();
+        }
+
+        let limits = ParseLimits {
+            max_points_per_stroke: 1,
+            ..ParseLimits::default()
+        };
+
+        let error = super::parse_page(&data, &limits).unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::LimitExceeded {
+                resource: "points per stroke",
                 limit: 1,
                 actual: 2,
             }

--- a/crates/sdocx/src/page.rs
+++ b/crates/sdocx/src/page.rs
@@ -200,7 +200,10 @@ fn parse_stroke(
         return None;
     }
 
-    let trailing = decode_trailing(data_blob, n_coord_bytes, points.len())?;
+    // The legacy page parser does not yet expose the native stroke property
+    // flag that declares tilt/orientation channels. Do not infer their presence
+    // from payload values, because flexible style bytes can look like angles.
+    let trailing = decode_trailing(data_blob, n_coord_bytes, points.len(), false)?;
     let next_record_off = data_end.checked_add(next_record_adjust)?;
 
     Some(ParsedStroke {

--- a/crates/sdocx/src/page.rs
+++ b/crates/sdocx/src/page.rs
@@ -1,3 +1,4 @@
+use crate::ParseLimits;
 use crate::decode::{decode_coordinates, decode_trailing};
 use crate::error::{Error, Result};
 use crate::types::{
@@ -19,7 +20,7 @@ struct ParsedStroke {
 /// Layout: `base = u32 @ 0x00`; stroke count at `base + 0x66`; first stroke at `base + 0xB5`.
 /// Each stroke is preceded by a 71-byte record; on v4.4.x+, byte 3 of that record encodes
 /// an extra-attribute-block length (value − 0x79) injected inside the stroke's metadata.
-pub fn parse_page(data: &[u8]) -> Result<Page> {
+pub fn parse_page(data: &[u8], limits: &ParseLimits) -> Result<Page> {
     if data.len() < 0xA0 {
         return Err(Error::Format("page file too short for header".into()));
     }
@@ -33,9 +34,19 @@ pub fn parse_page(data: &[u8]) -> Result<Page> {
 
     // Page UUID at 0x28, length at 0x26
     let uuid_char_len = u16::from_le_bytes(data[0x26..0x28].try_into().unwrap()) as usize;
-    let uuid_bytes = &data[0x28..0x28 + uuid_char_len * 2];
+    let uuid_byte_len = uuid_char_len
+        .checked_mul(2)
+        .ok_or_else(|| Error::Format("page UUID length overflow".into()))?;
+    let uuid_end = 0x28_usize
+        .checked_add(uuid_byte_len)
+        .ok_or_else(|| Error::Format("page UUID length overflow".into()))?;
+    let uuid_bytes = data
+        .get(0x28..uuid_end)
+        .ok_or_else(|| Error::Format("page file too short for UUID".into()))?;
     let uuid: String = uuid_bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| u16::from_le_bytes([c[0], c[1]]))
         .map(|c| char::from_u32(c as u32).unwrap_or('\u{FFFD}'))
         .collect();
@@ -52,25 +63,41 @@ pub fn parse_page(data: &[u8]) -> Result<Page> {
     let template = background_color.and_then(|_| page_template(data, base));
 
     // Stroke count at base + 0x66
-    let sc_off = base + 0x66;
-    if sc_off + 4 > data.len() {
-        return Err(Error::Format("page file too short for stroke count".into()));
-    }
-    let stroke_count = u32::from_le_bytes(data[sc_off..sc_off + 4].try_into().unwrap()) as usize;
+    let sc_off = base
+        .checked_add(0x66)
+        .ok_or_else(|| Error::Format("page stroke-count offset overflow".into()))?;
+    let stroke_count = read_u32(data, sc_off)
+        .ok_or_else(|| Error::Format("page file too short for stroke count".into()))?
+        as usize;
+    check_limit(
+        "strokes per page",
+        limits.max_strokes_per_page,
+        stroke_count,
+    )?;
 
     let mut strokes = Vec::with_capacity(stroke_count);
     // base + 0xB5 - 71 = base + 0x6E; byte 3 of that record is base + 0x71.
-    let mut record_off = base + 0xB5 - PRE_STROKE_RECORD_LEN;
+    let mut record_off = base
+        .checked_add(0xB5 - PRE_STROKE_RECORD_LEN)
+        .ok_or_else(|| Error::Format("first stroke offset overflow".into()))?;
 
     for _ in 0..stroke_count {
         let extra_len = data
-            .get(record_off + 3)
+            .get(record_off.saturating_add(3))
             .copied()
             .unwrap_or(EXTRA_LEN_BIAS)
             .saturating_sub(EXTRA_LEN_BIAS) as usize;
 
-        let off = record_off + PRE_STROKE_RECORD_LEN;
-        if off + STROKE_HEADER_LEN + extra_len > data.len() {
+        let Some(off) = record_off.checked_add(PRE_STROKE_RECORD_LEN) else {
+            break;
+        };
+        let Some(header_end) = off
+            .checked_add(STROKE_HEADER_LEN)
+            .and_then(|end| end.checked_add(extra_len))
+        else {
+            break;
+        };
+        if header_end > data.len() {
             break;
         }
 
@@ -87,12 +114,17 @@ pub fn parse_page(data: &[u8]) -> Result<Page> {
             (None, Some(shifted)) => shifted,
             (None, None) => break,
         };
+        check_limit(
+            "points per stroke",
+            limits.max_points_per_stroke,
+            parsed.stroke.points.len(),
+        )?;
 
         record_off = parsed.next_record_off;
         strokes.push(parsed.stroke);
     }
 
-    let elements = parse_page_elements(data, record_off, width, height);
+    let elements = parse_page_elements(data, record_off, width, height, limits)?;
 
     Ok(Page {
         uuid,
@@ -118,27 +150,40 @@ fn parse_stroke(
     extra_len: usize,
     layout: StrokeLayout,
 ) -> Option<ParsedStroke> {
+    let bbox_end = off.checked_add(32)?;
     let bbox = BoundingBox {
         x_min: read_f64(data, off)?,
-        y_min: read_f64(data, off + 8)?,
-        x_max: read_f64(data, off + 16)?,
-        y_max: read_f64(data, off + 24)?,
+        y_min: read_f64(data, off.saturating_add(8))?,
+        x_max: read_f64(data, off.saturating_add(16))?,
+        y_max: read_f64(data, off.saturating_add(24))?,
     };
 
-    let (meta_off, n_points_off, sp_off, next_record_adjust) = match layout {
-        StrokeLayout::Current => (off + 32 + extra_len, 39, off + 73 + extra_len, 0),
-        StrokeLayout::StartPointMinusThree => (off + 32, 36, off + 70, 3),
+    let offsets = match layout {
+        StrokeLayout::Current => bbox_end.checked_add(extra_len).zip(
+            off.checked_add(73)
+                .and_then(|offset| offset.checked_add(extra_len)),
+        ),
+        StrokeLayout::StartPointMinusThree => Some(bbox_end).zip(off.checked_add(70)),
+    };
+    let (meta_off, sp_off) = offsets?;
+    let (n_points_off, next_record_adjust) = match layout {
+        StrokeLayout::Current => (39, 0),
+        StrokeLayout::StartPointMinusThree => (36, 3),
     };
 
-    let data_len = read_u32(data, meta_off + 21)? as usize;
-    let n_points = read_u16(data, meta_off + n_points_off)? as usize;
+    let data_len_off = meta_off.checked_add(21)?;
+    let point_count_off = meta_off.checked_add(n_points_off)?;
+    let data_len = read_u32(data, data_len_off).map(|value| value as usize)?;
+    let n_points = read_u16(data, point_count_off).map(usize::from)?;
+
     let start_x = read_f64(data, sp_off)?;
-    let start_y = read_f64(data, sp_off + 8)?;
+    let start_y_off = sp_off.checked_add(8)?;
+    let start_y = read_f64(data, start_y_off)?;
     if !start_x.is_finite() || !start_y.is_finite() || n_points == 0 {
         return None;
     }
 
-    let data_off = sp_off + 16;
+    let data_off = sp_off.checked_add(16)?;
     let data_end = data_off.checked_add(data_len)?;
     if data_end > data.len() {
         return None;
@@ -156,6 +201,7 @@ fn parse_stroke(
     }
 
     let trailing = decode_trailing(data_blob, n_coord_bytes, points.len())?;
+    let next_record_off = data_end.checked_add(next_record_adjust)?;
 
     Some(ParsedStroke {
         stroke: Stroke {
@@ -168,26 +214,35 @@ fn parse_stroke(
             color: trailing.color,
             pen_width: trailing.pen_width,
         },
-        next_record_off: data_end + next_record_adjust,
+        next_record_off,
     })
 }
 
 fn read_u16(data: &[u8], offset: usize) -> Option<u16> {
-    Some(u16::from_le_bytes(
-        data.get(offset..offset + 2)?.try_into().ok()?,
-    ))
+    let end = offset.checked_add(2)?;
+    Some(u16::from_le_bytes(data.get(offset..end)?.try_into().ok()?))
 }
 
 fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
-    Some(u32::from_le_bytes(
-        data.get(offset..offset + 4)?.try_into().ok()?,
-    ))
+    let end = offset.checked_add(4)?;
+    Some(u32::from_le_bytes(data.get(offset..end)?.try_into().ok()?))
 }
 
 fn read_f64(data: &[u8], offset: usize) -> Option<f64> {
-    Some(f64::from_le_bytes(
-        data.get(offset..offset + 8)?.try_into().ok()?,
-    ))
+    let end = offset.checked_add(8)?;
+    Some(f64::from_le_bytes(data.get(offset..end)?.try_into().ok()?))
+}
+
+fn check_limit(resource: &'static str, limit: usize, actual: usize) -> Result<()> {
+    if actual > limit {
+        Err(Error::LimitExceeded {
+            resource,
+            limit: u64::try_from(limit).unwrap_or(u64::MAX),
+            actual: u64::try_from(actual).unwrap_or(u64::MAX),
+        })
+    } else {
+        Ok(())
+    }
 }
 
 fn page_background_color(data: &[u8], base: usize) -> Option<crate::types::Color> {
@@ -244,20 +299,28 @@ fn is_builtin_template_id(id: u32) -> bool {
     id != 0 && id <= 0xFFFF
 }
 
-fn parse_page_elements(data: &[u8], start: usize, width: u32, height: u32) -> Vec<PageElement> {
+fn parse_page_elements(
+    data: &[u8],
+    start: usize,
+    width: u32,
+    height: u32,
+    limits: &ParseLimits,
+) -> Result<Vec<PageElement>> {
     let mut elements = Vec::new();
     let mut image_count = 0;
 
-    for uuid_off in find_ascii_uuid_offsets(data, start) {
-        let Some(bbox) = find_object_bbox(data, uuid_off, width, height) else {
+    let mut uuid_off = find_next_ascii_uuid(data, start);
+    while let Some(current_uuid_off) = uuid_off {
+        let next_uuid = current_uuid_off
+            .checked_add(36)
+            .and_then(|start| find_next_ascii_uuid(data, start));
+        let record_end = next_uuid.unwrap_or(data.len());
+
+        let Some(bbox) = find_object_bbox(data, current_uuid_off, width, height) else {
+            uuid_off = next_uuid;
             continue;
         };
-
-        let next_uuid = find_ascii_uuid_offsets(data, uuid_off + 36)
-            .into_iter()
-            .next()
-            .unwrap_or(data.len());
-        let record = &data[uuid_off..next_uuid];
+        let record = &data[current_uuid_off..record_end];
 
         if let Some(text_box) = parse_text_box_record(record, bbox) {
             elements.push(PageElement::TextBox(text_box));
@@ -268,23 +331,29 @@ fn parse_page_elements(data: &[u8], start: usize, width: u32, height: u32) -> Ve
             });
             image_count += 1;
         }
+        check_limit(
+            "objects per page",
+            limits.max_objects_per_page,
+            elements.len(),
+        )?;
+        uuid_off = next_uuid;
     }
 
-    elements
+    Ok(elements)
 }
 
-fn find_ascii_uuid_offsets(data: &[u8], start: usize) -> Vec<usize> {
-    let mut offsets = Vec::new();
+fn find_next_ascii_uuid(data: &[u8], start: usize) -> Option<usize> {
     let mut offset = start;
-    while offset + 36 <= data.len() {
-        if is_ascii_uuid(&data[offset..offset + 36]) {
-            offsets.push(offset);
-            offset += 36;
-        } else {
-            offset += 1;
+    while let Some(end) = offset.checked_add(36) {
+        let Some(candidate) = data.get(offset..end) else {
+            break;
+        };
+        if is_ascii_uuid(candidate) {
+            return Some(offset);
         }
+        offset = offset.checked_add(1)?;
     }
-    offsets
+    None
 }
 
 fn is_ascii_uuid(bytes: &[u8]) -> bool {
@@ -510,8 +579,12 @@ fn infer_rotation_degrees(record: &[u8], bbox: BoundingBox) -> Option<f64> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_page;
-    use crate::types::{Color, PageTemplate, PageTemplateSource};
+    use crate::types::{Color, Page, PageTemplate, PageTemplateSource};
+    use crate::{Error, ParseLimits, Result};
+
+    fn parse_page(data: &[u8]) -> Result<Page> {
+        super::parse_page(data, &ParseLimits::default())
+    }
 
     #[test]
     fn parses_page_header_background_color() {
@@ -605,5 +678,26 @@ mod tests {
         let page = parse_page(&data).unwrap();
 
         assert_eq!(page.template, None);
+    }
+
+    #[test]
+    fn enforces_stroke_count_limit_before_allocating() {
+        let mut data = vec![0; 0xA8];
+        data[0x66..0x6A].copy_from_slice(&2_u32.to_le_bytes());
+        let limits = ParseLimits {
+            max_strokes_per_page: 1,
+            ..ParseLimits::default()
+        };
+
+        let error = super::parse_page(&data, &limits).unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::LimitExceeded {
+                resource: "strokes per page",
+                limit: 1,
+                actual: 2,
+            }
+        ));
     }
 }

--- a/crates/sdocx/src/page.rs
+++ b/crates/sdocx/src/page.rs
@@ -155,7 +155,7 @@ fn parse_stroke(
         return None;
     }
 
-    let trailing = decode_trailing(data_blob, n_coord_bytes, points.len().saturating_sub(1));
+    let trailing = decode_trailing(data_blob, n_coord_bytes, points.len())?;
 
     Some(ParsedStroke {
         stroke: Stroke {
@@ -163,8 +163,8 @@ fn parse_stroke(
             points,
             pressures: trailing.pressures,
             timestamps: trailing.timestamps,
-            tilt_x: trailing.tilt_x,
-            tilt_y: trailing.tilt_y,
+            tilts: trailing.tilts,
+            orientations: trailing.orientations,
             color: trailing.color,
             pen_width: trailing.pen_width,
         },

--- a/crates/sdocx/src/types.rs
+++ b/crates/sdocx/src/types.rs
@@ -339,9 +339,9 @@ pub struct Stroke {
     pub pressures: Vec<f64>,
     /// Per-point event timestamps in Samsung's native units.
     pub timestamps: Vec<i64>,
-    /// Stylus tilt values for each point, when recorded.
+    /// Stylus tilt values for each point when stream metadata identifies the channel.
     pub tilts: Vec<f64>,
-    /// Stylus orientation values for each point, when recorded.
+    /// Stylus orientation values for each point when stream metadata identifies the channel.
     pub orientations: Vec<f64>,
     /// Stroke color, if present.
     pub color: Option<Color>,

--- a/crates/sdocx/src/types.rs
+++ b/crates/sdocx/src/types.rs
@@ -93,6 +93,8 @@ pub struct Page {
 pub struct MediaAsset {
     /// Archive path.
     pub name: String,
+    /// Numeric archive resource ID from the filename prefix, when present.
+    pub archive_id: Option<u32>,
     /// MIME type, when recognized.
     pub mime_type: String,
     /// Raw media bytes.
@@ -112,6 +114,155 @@ pub enum PageElement {
     },
     /// A rich text object.
     TextBox(RichTextBox),
+}
+
+impl PageElement {
+    /// Return the S Pen SDK object type represented by this element.
+    pub const fn object_type(&self) -> ObjectType {
+        match self {
+            Self::Image { .. } => ObjectType::Image,
+            Self::TextBox(_) => ObjectType::TextBox,
+        }
+    }
+}
+
+/// Object type identifiers used by `SpenObjectBase`.
+///
+/// `Other` preserves identifiers introduced by newer SDKs instead of collapsing
+/// them into Samsung's explicit `Unknown` type (`19`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ObjectType {
+    /// No object (`0`).
+    None,
+    /// Pen stroke (`1`).
+    Stroke,
+    /// Text box (`2`).
+    TextBox,
+    /// Image (`3`).
+    Image,
+    /// Object container (`4`).
+    Container,
+    /// Shape (`7`).
+    Shape,
+    /// Line (`8`).
+    Line,
+    /// Deprecated dummy-stroke record (`9`).
+    DeprecatedDummyStroke,
+    /// Voice recording (`10`).
+    Voice,
+    /// Formula (`11`).
+    Formula,
+    /// Deprecated table record (`12`).
+    DeprecatedTable,
+    /// Web object (`13`).
+    Web,
+    /// Painting (`14`).
+    Painting,
+    /// Development-version stroke (`15`).
+    StrokeDevelopmentVersion,
+    /// Video (`16`).
+    Video,
+    /// Link (`17`).
+    Link,
+    /// Brush stroke (`18`).
+    StrokeBrush,
+    /// Samsung's explicit unknown-object marker (`19`).
+    Unknown,
+    /// Plot (`20`).
+    Plot,
+    /// Math object (`21`).
+    Math,
+    /// Current table object (`22`).
+    Table,
+    /// Code block (`23`).
+    CodeBlock,
+    /// Attached file (`24`).
+    AttachedFile,
+    /// Stroke group (`100`).
+    StrokeGroup,
+    /// Identifier not known to this version of the library.
+    Other(u32),
+}
+
+impl ObjectType {
+    /// Return the raw `SpenObjectBase` type identifier.
+    pub const fn raw(self) -> u32 {
+        match self {
+            Self::None => 0,
+            Self::Stroke => 1,
+            Self::TextBox => 2,
+            Self::Image => 3,
+            Self::Container => 4,
+            Self::Shape => 7,
+            Self::Line => 8,
+            Self::DeprecatedDummyStroke => 9,
+            Self::Voice => 10,
+            Self::Formula => 11,
+            Self::DeprecatedTable => 12,
+            Self::Web => 13,
+            Self::Painting => 14,
+            Self::StrokeDevelopmentVersion => 15,
+            Self::Video => 16,
+            Self::Link => 17,
+            Self::StrokeBrush => 18,
+            Self::Unknown => 19,
+            Self::Plot => 20,
+            Self::Math => 21,
+            Self::Table => 22,
+            Self::CodeBlock => 23,
+            Self::AttachedFile => 24,
+            Self::StrokeGroup => 100,
+            Self::Other(raw) => raw,
+        }
+    }
+
+    /// Whether this object type is available in the supplied format version.
+    pub const fn is_supported_by(self, version: FormatVersion) -> bool {
+        match self {
+            Self::Math => version.supports_math_objects(),
+            Self::Table | Self::CodeBlock => version.supports_table_and_code_block_objects(),
+            _ => true,
+        }
+    }
+}
+
+impl From<u32> for ObjectType {
+    fn from(raw: u32) -> Self {
+        match raw {
+            0 => Self::None,
+            1 => Self::Stroke,
+            2 => Self::TextBox,
+            3 => Self::Image,
+            4 => Self::Container,
+            7 => Self::Shape,
+            8 => Self::Line,
+            9 => Self::DeprecatedDummyStroke,
+            10 => Self::Voice,
+            11 => Self::Formula,
+            12 => Self::DeprecatedTable,
+            13 => Self::Web,
+            14 => Self::Painting,
+            15 => Self::StrokeDevelopmentVersion,
+            16 => Self::Video,
+            17 => Self::Link,
+            18 => Self::StrokeBrush,
+            19 => Self::Unknown,
+            20 => Self::Plot,
+            21 => Self::Math,
+            22 => Self::Table,
+            23 => Self::CodeBlock,
+            24 => Self::AttachedFile,
+            100 => Self::StrokeGroup,
+            raw => Self::Other(raw),
+        }
+    }
+}
+
+impl From<ObjectType> for u32 {
+    fn from(object_type: ObjectType) -> Self {
+        object_type.raw()
+    }
 }
 
 /// Parsed rich text box data.
@@ -195,6 +346,13 @@ pub struct Stroke {
     pub pen_width: f32,
 }
 
+impl Stroke {
+    /// Return the S Pen SDK object type represented by a parsed stroke.
+    pub const fn object_type(&self) -> ObjectType {
+        ObjectType::Stroke
+    }
+}
+
 /// A 2D point.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -239,5 +397,29 @@ impl Default for BoundingBox {
             x_max: 0.0,
             y_max: 0.0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FormatVersion, ObjectType};
+
+    #[test]
+    fn object_type_ids_round_trip_without_losing_future_values() {
+        for raw in 0..=100 {
+            let object_type = ObjectType::from(raw);
+            assert_eq!(object_type.raw(), raw);
+        }
+        assert_eq!(ObjectType::from(19), ObjectType::Unknown);
+        assert_eq!(ObjectType::from(25), ObjectType::Other(25));
+    }
+
+    #[test]
+    fn version_gates_match_current_sdk_contract() {
+        assert!(!ObjectType::Math.is_supported_by(FormatVersion(5199)));
+        assert!(ObjectType::Math.is_supported_by(FormatVersion::MATH_OBJECTS));
+        assert!(!ObjectType::Table.is_supported_by(FormatVersion(5399)));
+        assert!(ObjectType::Table.is_supported_by(FormatVersion::TABLE_AND_CODE_BLOCK_OBJECTS));
+        assert!(ObjectType::Stroke.is_supported_by(FormatVersion::INITIAL));
     }
 }

--- a/crates/sdocx/src/types.rs
+++ b/crates/sdocx/src/types.rs
@@ -146,14 +146,14 @@ pub struct Stroke {
     pub bbox: BoundingBox,
     /// The (x, y) coordinates along the stroke path.
     pub points: Vec<Point>,
-    /// Pressure values for each point, normalized to `[0.0, 1.0]`.
+    /// Pressure values for each point as exposed by the S Pen SDK.
     pub pressures: Vec<f64>,
-    /// Timestamps for each point in milliseconds since the Unix epoch.
+    /// Per-point event timestamps in Samsung's native units.
     pub timestamps: Vec<i64>,
-    /// Stylus tilt along the X axis for each point.
-    pub tilt_x: Vec<i64>,
-    /// Stylus tilt along the Y axis for each point.
-    pub tilt_y: Vec<i64>,
+    /// Stylus tilt values for each point, when recorded.
+    pub tilts: Vec<f64>,
+    /// Stylus orientation values for each point, when recorded.
+    pub orientations: Vec<f64>,
     /// Stroke color, if present.
     pub color: Option<Color>,
     /// Pen width in pixels.

--- a/crates/sdocx/src/types.rs
+++ b/crates/sdocx/src/types.rs
@@ -12,6 +12,8 @@ pub struct Document {
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DocumentMetadata {
+    /// Samsung Notes binary format version recorded by the archive.
+    pub format_version: Option<FormatVersion>,
     /// Creation timestamp in milliseconds since the Unix epoch.
     pub created_ms: Option<i64>,
     /// Last modification timestamp in milliseconds since the Unix epoch.
@@ -28,6 +30,39 @@ pub struct DocumentMetadata {
     pub media_assets: Vec<MediaAsset>,
     /// Top-level typed note text from `note.note`, if present.
     pub note_text: Option<RichTextBox>,
+}
+
+/// Samsung Notes binary format version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FormatVersion(pub u16);
+
+impl FormatVersion {
+    /// Earliest version recognized by the current S Pen SDK.
+    pub const INITIAL: Self = Self(2034);
+    /// Minimum version accepted by current Samsung Notes builds.
+    pub const MINIMUM_SUPPORTED: Self = Self(4000);
+    /// Version that introduced math objects.
+    pub const MATH_OBJECTS: Self = Self(5200);
+    /// Version that introduced table and code-block objects.
+    pub const TABLE_AND_CODE_BLOCK_OBJECTS: Self = Self(5400);
+    /// Current format version exposed by the analyzed SDK.
+    pub const CURRENT: Self = Self(5500);
+
+    /// Return the raw numeric format version.
+    pub const fn raw(self) -> u16 {
+        self.0
+    }
+
+    /// Whether this version can contain math objects.
+    pub const fn supports_math_objects(self) -> bool {
+        self.0 >= Self::MATH_OBJECTS.0
+    }
+
+    /// Whether this version can contain table and code-block objects.
+    pub const fn supports_table_and_code_block_objects(self) -> bool {
+        self.0 >= Self::TABLE_AND_CODE_BLOCK_OBJECTS.0
+    }
 }
 
 /// A single page within a document.

--- a/crates/sdocx/src/types.rs
+++ b/crates/sdocx/src/types.rs
@@ -104,6 +104,7 @@ pub struct MediaAsset {
 /// A non-stroke page element.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum PageElement {
     /// A placed image object.
     Image {
@@ -132,6 +133,7 @@ impl PageElement {
 /// them into Samsung's explicit `Unknown` type (`19`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum ObjectType {
     /// No object (`0`).
     None,
@@ -314,6 +316,7 @@ pub struct PageTemplate {
 /// Page template backing source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum PageTemplateSource {
     /// Built-in Samsung Notes page template.
     BuiltIn,

--- a/crates/sdocx/tests/archive_contracts.rs
+++ b/crates/sdocx/tests/archive_contracts.rs
@@ -43,3 +43,16 @@ fn archive_entry_limit_is_configurable() {
         } if actual > 1
     ));
 }
+
+#[test]
+fn media_filename_resource_id_is_preserved() {
+    let document = sdocx::parse(sample_path("quiz.sdocx")).unwrap();
+    let asset = document
+        .metadata
+        .media_assets
+        .iter()
+        .find(|asset| asset.name.ends_with("@files_230820_133807_215.png"))
+        .unwrap();
+
+    assert_eq!(asset.archive_id, Some(7));
+}

--- a/crates/sdocx/tests/archive_contracts.rs
+++ b/crates/sdocx/tests/archive_contracts.rs
@@ -14,6 +14,8 @@ fn sample_exposes_format_version_and_authoritative_page_order() {
     let document = sdocx::parse(sample_path("handwritten.sdocx")).unwrap();
 
     assert_eq!(document.metadata.format_version, Some(FormatVersion(4000)));
+    assert!(!document.metadata.page_ids.is_empty());
+    assert_eq!(document.pages.len(), document.metadata.page_ids.len());
     assert!(
         document
             .pages

--- a/crates/sdocx/tests/archive_contracts.rs
+++ b/crates/sdocx/tests/archive_contracts.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use sdocx::{Error, FormatVersion, ParseOptions};
+
+fn sample_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("samples")
+        .join(name)
+}
+
+#[test]
+fn sample_exposes_format_version_and_authoritative_page_order() {
+    let document = sdocx::parse(sample_path("handwritten.sdocx")).unwrap();
+
+    assert_eq!(document.metadata.format_version, Some(FormatVersion(4000)));
+    assert!(
+        document
+            .pages
+            .iter()
+            .zip(&document.metadata.page_ids)
+            .all(|(page, page_id)| page.uuid == *page_id)
+    );
+}
+
+#[test]
+fn archive_entry_limit_is_configurable() {
+    let options = ParseOptions {
+        limits: sdocx::ParseLimits {
+            max_archive_entries: 1,
+            ..sdocx::ParseLimits::default()
+        },
+    };
+
+    let error = sdocx::parse_with_options(sample_path("quiz.sdocx"), &options).unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::LimitExceeded {
+            resource: "archive entry count",
+            limit: 1,
+            actual,
+        } if actual > 1
+    ));
+}

--- a/crates/sdocx/tests/stroke_channels.rs
+++ b/crates/sdocx/tests/stroke_channels.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+fn sample_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("samples")
+        .join(name)
+}
+
+#[test]
+fn sample_stroke_channels_align_with_points() {
+    for name in ["cs61bl_su22.sdocx", "handwritten.sdocx", "quiz.sdocx"] {
+        let document = sdocx::parse(sample_path(name)).unwrap();
+        let mut stroke_count = 0;
+
+        for stroke in document.pages.iter().flat_map(|page| &page.strokes) {
+            stroke_count += 1;
+            assert_eq!(stroke.pressures.len(), stroke.points.len(), "{name}");
+            assert_eq!(stroke.timestamps.len(), stroke.points.len(), "{name}");
+            assert!(stroke.pressures.iter().all(|value| value.is_finite()));
+
+            if !stroke.tilts.is_empty() || !stroke.orientations.is_empty() {
+                assert_eq!(stroke.tilts.len(), stroke.points.len(), "{name}");
+                assert_eq!(stroke.orientations.len(), stroke.points.len(), "{name}");
+                assert!(stroke.tilts.iter().all(|value| value.is_finite()));
+                assert!(stroke.orientations.iter().all(|value| value.is_finite()));
+            }
+        }
+
+        assert!(stroke_count > 0, "{name} should contain strokes");
+    }
+}

--- a/crates/sdocx/tests/stroke_channels.rs
+++ b/crates/sdocx/tests/stroke_channels.rs
@@ -19,12 +19,8 @@ fn sample_stroke_channels_align_with_points() {
             assert_eq!(stroke.timestamps.len(), stroke.points.len(), "{name}");
             assert!(stroke.pressures.iter().all(|value| value.is_finite()));
 
-            if !stroke.tilts.is_empty() || !stroke.orientations.is_empty() {
-                assert_eq!(stroke.tilts.len(), stroke.points.len(), "{name}");
-                assert_eq!(stroke.orientations.len(), stroke.points.len(), "{name}");
-                assert!(stroke.tilts.iter().all(|value| value.is_finite()));
-                assert!(stroke.orientations.iter().all(|value| value.is_finite()));
-            }
+            assert!(stroke.tilts.is_empty(), "{name}");
+            assert!(stroke.orientations.is_empty(), "{name}");
         }
 
         assert!(stroke_count > 0, "{name} should contain strokes");


### PR DESCRIPTION
## Summary

- decode packed stroke coordinates and trailing channels without truncating native values
- honor format metadata and page ordering, reject protected documents, and enforce configurable parse limits
- preserve object and media identifiers while keeping public enums forward-compatible
- avoid guessing optional stylus channels and document the best-effort semantic parsing boundary

## Validation

- `cargo fmt --all --check`
- `cargo clippy -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo +1.88.0 check --workspace --all-targets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable parsing limits for archive size, pages, strokes, points, and objects.
  * Added format-version and media archive ID metadata.
  * Improved stroke data support, including pressure, timestamps, tilt, and orientation channels.
  * Added safer handling for protected documents and unsupported content.

* **Bug Fixes**
  * Improved page ordering and parsing of malformed documents.
  * Clamped invalid stroke pressure values to prevent excessive rendering widths.

* **Documentation**
  * Documented parser accuracy, format coverage, limitations, and protected-document requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->